### PR TITLE
Records partial answer as soon as student click/type.

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -462,8 +462,23 @@ class Work(db.Model):
                 return True
         return False
 
+    def save_partials(self):
+        """
+        Exit early if `self` is submitted.
+        Doesn't mark the work as submitted, count the points and commit.
+        This is used when a student click a radio element.
+        Not when he clicks on "Envoyer" button.
+        """
+        if self.is_submitted:
+            return
+        self.count_points()
+        db.session.commit()
+
     def record(self):
-        """Mark the work as submitted, count the points and commit."""
+        """
+        Marks the work as submitted, count the points and commit.
+        This is used when a student clicks on "Envoyer" button.
+        """
         self.is_submitted = True
         self.count_points()
         db.session.commit()

--- a/src/static/javascript/submit_partials.js
+++ b/src/static/javascript/submit_partials.js
@@ -1,0 +1,22 @@
+/*
+* Open and send an AJAX request to a give URL
+* We make sure to insert the CSRF token (for flask validation)
+* 
+* partials: (object) will be send as JSON
+* url: (string) the destination url
+* csrf_token: (string) the csrf_token attached to the sending form
+*/
+function send_xhr(partials, url, csrf_token) {
+    // Creating a XHR object
+    let xhr = new XMLHttpRequest();
+    // open a connection
+    xhr.open("POST", url, true);
+    // insert CSRF token to avoid 400(bad request) response from Flask
+    xhr.setRequestHeader("X-CSRFToken", csrf_token);
+    // Set the request header i.e. which type of content you are sending
+    xhr.setRequestHeader("Content-Type", "application/json");
+    // Converting JSON data to string
+    let data = JSON.stringify(partials);
+    // Sending data with the request
+    xhr.send(data);
+}

--- a/src/templates/qcm.html
+++ b/src/templates/qcm.html
@@ -20,7 +20,13 @@ table {
             {{ qcm.title|safe }}
         </h1>
     </div>
-    <form method="POST" action="{{ url_for('answers') }}" id="qcm_form" accept-charset="UTF-8" enctype="application/x-www-form-urlencoded;charset=UTF-8">
+    <form 
+        method="POST" 
+        action="{{ url_for('answers') }}" 
+        id="qcm_form" 
+        accept-charset="UTF-8" 
+        enctype="application/x-www-form-urlencoded;charset=UTF-8"
+    >
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         {% for p_index, part in enumerate(qcm.shuffled_parts()) %}
         <div class="part">
@@ -41,10 +47,31 @@ table {
                 </p>
                 {% if question.is_text_question %}
                 <div class="answer">
-                    <textarea name="T_{{ question.id }}" id="Q_{{ question.id }}" cols="40" rows="5"></textarea>
+                    <textarea 
+                        name="T_{{ question.id }}" 
+                        id="Q_{{ question.id }}" 
+                        cols="40" 
+                        rows="5"
+                        onblur="this.form.send_partials();"
+                    ></textarea>
                 </div>
                 {% else %}
                 <div class="answers">
+                    <div class="answer" id="answer_A_F_{{ question.id }}">
+                        <input 
+                            type="radio" 
+                            name="Q_{{ question.id }}" 
+                            id="A_F_{{ question.id }}" 
+                            value="F"
+                            autocomplete="off"
+                            class="radio"
+                            onchange="this.form.send_partials();"
+                        >
+                        </input>
+                        <label for="A_F_{{ question.id }}">
+                            <em>Je ne sais pas</em>
+                        </label>
+                    </div>
                     {% for answer in question.shuffled_answers() %}
                     <div class="answer" id="answer_A_{{ answer.id }}">
                         <input 
@@ -54,6 +81,7 @@ table {
                             value="A_{{ answer.id }}"
                             autocomplete="off"
                             class="radio"
+                            onchange="this.form.send_partials();"
                         >
                         </input>
                         <label for="A_{{ answer.id }}">
@@ -79,6 +107,61 @@ table {
 <script id="chosen_label_switcher" src={{ url_for('static', filename='javascript/chosen_label_theme_switcher.js') }}>
 </script>
 {% if not preview %}
+    <script src={{ url_for('static', filename='javascript/submit_partials.js') }}>
+    </script>
+    <script>
+        // TODO move this ugly script elsewhere, make it a function using sent data.
+        // This ugly script has to stay here atm...
+        // We're writing some part of it from Jinja.
+        // We should find a way to make it a json object to call a function.
+
+        
+        let qcm_form = document.getElementById("qcm_form");
+        /*
+        * Called when the user click on a label or leaves a textarea zone.
+        * Is used to get partials results even if the student doest submit his answers.
+        * This will allow us to get results from student who :
+        * start the QCM when it is opened
+        * select some answers
+        * click on Envoyer too late ie. When it is closed.
+        * We select every textarea and clicked label, make it into a JSON object and 
+        * send it back to us with AJAX request.
+        */
+        qcm_form.send_partials = function() {
+            let partials = {
+                "id": {{ qcm.id|safe }},
+            };
+            {% for p_index, part in enumerate(qcm.part) %}
+                {% for question in part.questions %}
+                    {% if question.is_text_question %}
+                        try {
+                            let q_t = document.getElementById("Q_{{ question.id }}").value;
+                            partials['T_{{ question.id }}'] = q_t;
+                        } catch(error) {
+                            if (! (error instanceof TypeError) ) {
+                                console.log(error);
+                            } 
+                        } 
+                    {% else %}
+                        try {
+                            let q_a = document.querySelector(
+                                'input[name="Q_{{ question.id }}"]:checked'
+                            ).value;
+                            partials['Q_{{ question.id }}'] = q_a;
+                        } catch(error) {
+                            if (! (error instanceof TypeError) ) {
+                                console.log(error);
+                            } 
+                        } 
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+
+            let csrf_token = "{{ csrf_token() }}";
+            let url = "{{ url_for('partials') }}";
+            send_xhr(partials, url, csrf_token);
+        }
+    </script>
     <script id="anticheat" src={{ url_for('static', filename='javascript/anticheat.js') }}>
     </script>
 {% endif %}


### PR DESCRIPTION
# Record partial answers.

It's a heavy one.

## Problem

When a QCM is open, a student can access it.
If the teacher closes the QCM, the student can't submit anymore. The student would have no point even if the answer is sent 1 second too late.

## Solution

**Record partial answers as soon as a student types something or selects an answer.**

It allows us to have 'partial' answers for a student who started the QCM on time (when it was opened) and finished it late (when it was closed).

A js function is called every time a radio is clicked or a textarea lose focus and send an AJAX request with the student answers as a JSON object.

It is then recorded normally since the format is the same.

The only difference with a "_Envoyer_" answer is this work isn't marked as "submitted" (on purpose).

It will generate A LOT of requests, which is bad...

I had to add a "_Je ne sais pas_" answer for every radio choice in first position (ie. selected by default). It may go if I find a better way.

I had to write a lot of "dynamic JS" ie. JS with Jinja elements... which is prone to errors.
I would like to change that, but I'll have to serialize the (questions, answers) object. Might not be that difficult.

## Other solutions

* Ignore the submission completely ie. what we already have. Disappointing for the student.
* Accept late answers, marked as "x mins late". It will require us to set a "due" date and will complicate the teacher task. It is definitely simpler. I fear the almost impossible situation where a student get the `id_qcm` and forge a request at home... 
    This simpler solution only requires a few database changes.

